### PR TITLE
Removing the fn/ln differentiator

### DIFF
--- a/OutsuranceAssessment.Helpers/PersonHelper.cs
+++ b/OutsuranceAssessment.Helpers/PersonHelper.cs
@@ -37,10 +37,10 @@ namespace OutsuranceAssessment.Helpers
 
         public List<PersonName> GetPersonNames(List<Person> people)
         {
-            var names = people.Select(x => new PersonName { Name = x.FirstName, Type = "fn", Count = 1 })
-                .Concat(people.Select(y => new PersonName { Name = y.LastName, Type = "ln", Count = 1 }))
+            var names = people.Select(x => new PersonName { Name = x.FirstName,  Count = 1 })
+                .Concat(people.Select(y => new PersonName { Name = y.LastName, Count = 1 }))
                 .GroupBy(a => a.Name)
-                .Select(b => new PersonName { Name = b.First().Name, Type = b.First().Type, Count = b.Sum(c => c.Count) })
+                .Select(b => new PersonName { Name = b.First().Name, Count = b.Sum(c => c.Count) })
                 .OrderByDescending(o1 => o1.Count)
                 .ThenBy(o2 => o2.Name)
                 .ToList();

--- a/OutsuranceAssessment.Models/PersonName.cs
+++ b/OutsuranceAssessment.Models/PersonName.cs
@@ -4,7 +4,6 @@ namespace OutsuranceAssessment.Models
     public class PersonName
     {
         public string Name { get; set; }
-        public string Type { get; set; }
         public int Count { get; set; }
     }
 }

--- a/OutsuranceAssessment.Test/PeopleStats_UnitTests.cs
+++ b/OutsuranceAssessment.Test/PeopleStats_UnitTests.cs
@@ -92,20 +92,17 @@ namespace OutsuranceAssessment.Test
             expectedResult.Add(new PersonName
             {
                 Name = "Lawrence",
-                Count = 2,
-                Type = "ln"
+                Count = 2
             });
             expectedResult.Add(new PersonName
             {
                 Name = "Christina",
-                Count = 1,
-                Type = "fn"
+                Count = 1
             });
             expectedResult.Add(new PersonName
             {
                 Name = "Reuel",
-                Count = 1,
-                Type = "fn"
+                Count = 1
             });
 
             Assert.That(expectedResult, NUnit.DeepObjectCompare.Is.DeepEqualTo(actualResult));

--- a/OutsuranceAssessment/SampleInput.csv
+++ b/OutsuranceAssessment/SampleInput.csv
@@ -2,3 +2,4 @@
 Christina,Lawrence,22 Helmcroft Crescent
 Sheila,Lawrence,317 Wren Avenue
 Christina,Nair,342 Hillgrove Dr
+Lawrence,Fishbourne,99 Alpha Street


### PR DESCRIPTION
Removed the firstName, lastName differentiation from the output as this requirement was not specified in the acceptance criteria, and the feature adds unnecessary complexity to the solution.